### PR TITLE
Augmentation de la longueur du champ guildName à 100 caractère

### DIFF
--- a/apps/backend/src/discord-server/entities/discord-server-entity.ts
+++ b/apps/backend/src/discord-server/entities/discord-server-entity.ts
@@ -6,7 +6,7 @@ export class DiscordServer {
 	@PrimaryColumn({ type: 'varchar', length: 32 })
 	guildId: string; // Identifiant du serveur Discord (guild) -- PRIMARY KEY
 
-	@Column({ type: 'varchar', length: 32, nullable: true })
+	@Column({ type: 'varchar', length: 100, nullable: true })
 	guildName?: string; // Nom du serveur Discord (guild)
 
 	@Column({ type: 'varchar', length: 32, nullable: true })


### PR DESCRIPTION
…l'entité DiscordServer pour permettre des noms de serveur plus longs.